### PR TITLE
Making pip always pull upgraded packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,5 +3,5 @@ ENV PYTHONUNBUFFERED 1
 RUN mkdir /code
 WORKDIR /code
 ADD requirements.txt /code
-RUN pip install -r requirements.txt --src /usr/local/src
+RUN pip install -U -r requirements.txt --src /usr/local/src
 ADD . /code/


### PR DESCRIPTION
- this is to fix a problem where the latest designstandards repo was not
  being updated, because it's not on PyPI

cc @noonkay 
