### PR TITLE
Remove deprecated urls.patterns (Fixes #101)

### DIFF
--- a/principal_travel/urls.py
+++ b/principal_travel/urls.py
@@ -38,7 +38,7 @@ urlpatterns = [
 
 if settings.DEBUG:
     import debug_toolbar
-    urlpatterns += patterns('',
+    urlpatterns += [
         url(r'^__debug__/', include(debug_toolbar.urls)),
         url(r'^static/(?P<path>.*)$', views.serve),
-    )
+    ]


### PR DESCRIPTION
[101](https://github.com/CommerceDataService/ITA_Principal_Travel/issues/101)

Changed syntax and removed deprecated `django.conf.urls.patterns()`
