### PR TITLE
Fixing the bug on Domestic view of dashboard 

### DIFF
--- a/principal_travel/static/js/script.js
+++ b/principal_travel/static/js/script.js
@@ -143,15 +143,6 @@ var renderMap = function(tripData){
       }
     });
   });
-
-  $( "input" ).on('click', function( event ) {
-    var layerClicked = window[event.target.value];
-    if (map.hasLayer(layerClicked)) {
-      map.removeLayer(layerClicked);
-    } else {
-      map.addLayer(layerClicked);
-    }
-  });
 };
 
 var renderChart = function(tripData, eventData, reports){
@@ -219,17 +210,27 @@ var getData = function(destination){
 };
 
 var loadDefaults = function(){
-  getData('international');
-};
-
-$(document).ready(function(){
   map = new L.map('map') //initializes the map
   .setView([33, -8], 2);
+
   $(function(argument) { //initializes the toggle button
     $('[type="checkbox"]').bootstrapSwitch();
     $('.destroy-switch').bootstrapSwitch('destroy');
   });
 
+  getData('international');
+
+  $( "input" ).on('click', function( event ) {
+    var layerClicked = window[event.target.value];
+    if (map.hasLayer(layerClicked)) {
+      map.removeLayer(layerClicked);
+    } else {
+      map.addLayer(layerClicked);
+    }
+  });
+};
+
+$(document).ready(function(){
   $('#dashtoggle').on('switchChange.bootstrapSwitch', function(event, state) {
     if(state){ //true state is the default: international
       getData('international');


### PR DESCRIPTION
The toggling of layers with the checkboxes wasn't working because the event listener was firing off twice. I moved it to a function that doesn't run again on toggling between Domestic and International.
